### PR TITLE
Add NS to RewriteRule; Sanitize URL; Handle URLs w/ no query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The rewrite rule finds that /redcap_v8.1.0/index.php is NOT a valid file but has
     # Check that the requested URI looks like a REDCap URI
     RewriteCond %{REQUEST_URI} "^.*\/redcap_v(\d+\.\d+\.\d+)\/.*$"
     # Redirect to this script to handle the version substitution
-    RewriteRule "^(.+)$"   "/redcap_redirect.php"   [PT,L]
+    RewriteRule "^(.+)$"   "/redcap_redirect.php"   [PT,L,NS]
 </IfModule>
 ```
 

--- a/redcap_redirect.php
+++ b/redcap_redirect.php
@@ -4,6 +4,8 @@
  * REDCap REDIRECT
  * 
  * Author: Andrew Martin (andy123@stanford.edu)
+ * Addtions by: Tony Jin (Tony.Jin@stonybrookmedicine.edu)
+ *              Andy Arenson (aarenson@iu.edu)
  *
  * This script is used in conjunction with an apache mod_rewrite rule to automatically fix outdated REDCap URLs
  *
@@ -21,7 +23,7 @@
         # Check that the requested URI looks like a REDCap URI
         RewriteCond %{REQUEST_URI} "^.*\/redcap_v(\d+\.\d+\.\d+)\/.*$"
         # Redirect to this script to handle the version substitution
-        RewriteRule "^(.+)$"     "/redcap_redirect.php"   [PT,L]
+        RewriteRule "^(.+)$"     "/redcap_redirect.php"   [PT,L,NS]
      </IfModule>
 
  * Note: if your redcap server is not installed in the DOCUMENT_ROOT, then you may need to modify the RewriteRule line
@@ -38,10 +40,10 @@ require_once("redcap_connect.php");
 /* @var string $redcap_version */
 global $homepage_contact_email, $redcap_version;
 
-$requestUri = $_SERVER['REQUEST_URI'];
+$requestUri = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
 
 // Check the redirectURL for a redcap version - https://regex101.com/r/jisap2/1
-$re = '/^(.*\/redcap_v)(\d+\.\d+\.\d+)(\/.*)(\?.*)$/';
+$re = '/^(.*\/redcap_v)(\d+\.\d+\.\d+)(\/.*?)(\?.*)*$/';
 preg_match($re, $requestUri, $uriMatches);
 $uriVersion = empty($uriMatches[2]) ? NULL : $uriMatches[2];
 

--- a/redcap_redirect.php
+++ b/redcap_redirect.php
@@ -4,7 +4,7 @@
  * REDCap REDIRECT
  * 
  * Author: Andrew Martin (andy123@stanford.edu)
- * Addtions by: Tony Jin (Tony.Jin@stonybrookmedicine.edu)
+ * Additions by: Tony Jin (Tony.Jin@stonybrookmedicine.edu)
  *              Andy Arenson (aarenson@iu.edu)
  *
  * This script is used in conjunction with an apache mod_rewrite rule to automatically fix outdated REDCap URLs


### PR DESCRIPTION
Adding NS to RewriteRule allows one to follow external module links from the left hand side navigation within a project to that external module's plugin page.

I'm not sure how one would exploit an unsanitized URL, but it seems like a good idea, in general, to sanitize input, and the redcap_redirect.php script can be reached directly. This sanitization was in the version that Tony Jin had posted.

I rewrote what Tony Jin's version had done for handling URLs that didn't have query params. His version cut out the fourth section of the regex and later used code to examine the third section and if there were query parameters found to split them off. I was able to rewrite the original regex so that the third and fourth sections would correctly match whether or not the URL had any query params.