### PR TITLE
Clarify IIS setup for REDCap in subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ a2enmod rewrite
 				<add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
 				<add input="{REQUEST_URI}" pattern="^.*\/redcap_v(\d+\.\d+\.\d+)\/.*$" />
 			</conditions>
-			<action type="Rewrite" url="/path/to/redcap_redirect.php" appendQueryString="false" />
+			<!-- Change the url value if REDCap is in a sub-directory, e.g. url="/redcap/redcap_redirect.php" -->
+			<action type="Rewrite" url="/redcap_redirect.php" appendQueryString="false" />
 		</rule>
 	</rules>
 </rewrite>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ a2enmod rewrite
 				<add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
 				<add input="{REQUEST_URI}" pattern="^.*\/redcap_v(\d+\.\d+\.\d+)\/.*$" />
 			</conditions>
-			<action type="Rewrite" url="/redcap_redirect.php" appendQueryString="false" />
+			<action type="Rewrite" url="/path/to/redcap_redirect.php" appendQueryString="false" />
 		</rule>
 	</rules>
 </rewrite>


### PR DESCRIPTION
Clarified "/path/to"/redcap_redirect.php in the IIS install section for REDCap instances that are hosted in nested folders under webroot.